### PR TITLE
Updates class-woosidebars-sbm-converter.php

### DIFF
--- a/classes/class-woosidebars-sbm-converter.php
+++ b/classes/class-woosidebars-sbm-converter.php
@@ -396,7 +396,7 @@ class Woosidebars_SBM_Converter {
 			$response['post_name'] = esc_attr( $v['conditionals']['sidebar_id'] );
 		} else {
 			$this->not_converted[$k] = $v; // Keep a log of this item, which wasn't converted.
-			continue; // Skip this one, as we don't have a proper slug.
+			return; // Skip this one, as we don't have a proper slug.
 		}
 
 		// Conditions.


### PR DESCRIPTION
This fixes #1 

Replaces `continue` with `return` here: https://github.com/woothemes/woosidebars-sbm-converter/blob/master/classes/class-woosidebars-sbm-converter.php#L399 as `continue` is used outside loop and illegal, causing fatal errors in PHP7

Cheers! 
